### PR TITLE
Added @rclnodejs scope to package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ref-struct-di
 =============
+*THIS PACKAGE WAS FORKED FROM http://github.com/node-ffi-napi/ref-struct-di AND UPDATED TO 
+ENABLE [rclnodejs](https://github.com/RobotWebTools/rclnodejs) TO RUN UNDER NODE VERSIONS 12-16. NO TESTING BEYOND the rclnodejs TEST SUITE
+HAS BEEN PERFORMED. USE AT YOUR OWN DISCRETION.*
 ### Create ABI-compliant "[struct][]" instances on top of Buffers
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/node-ffi-napi/ref-struct-di.svg)](https://greenkeeper.io/)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ref-struct-di",
+  "name": "@rclnodejs/ref-struct-di",
   "description": "Create ABI-compliant \"struct\" instances on top of Buffers",
   "keywords": [
     "struct",
@@ -16,7 +16,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/node-ffi-napi/ref-struct-di.git"
+    "url": "git://github.com/rclnodejs/ref-struct-di.git"
   },
   "main": "./lib/struct.js",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "nyc": "^15.0.0",
     "node-gyp-build": "^4.2.1",
     "node-addon-api": "^3.0.0",
-    "ref-array-di": "^1.2.2",
-    "ref-napi": "^3.0.2"
+    "@rclnodejs/ref-array-di": "^1.2.2",
+    "@rclnodejs/ref-napi": "^4.0.0"
   }
 }


### PR DESCRIPTION
Convert package to a scoped package under the @rclnodejs scope name. As a scoped package it will be less likely to be used for general purposes.