### PR TITLE
Fix tests to use @rclnodejs scoped packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,25 @@ sudo: false
 
 dist: bionic
 
+os:
+  - linux
+  - osx
+
+osx_image: xcode12
+
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+    packages:
+      - g++
 
 language: node_js
 
 node_js:
+  - "10"
+  - "12"
   - "14"
-  - "15"
   - "16"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 
+dist: bionic
+
 addons:
   apt:
     sources:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
     # node.js
     - nodejs_version: "14"
     - nodejs_version: "15"
+    - nodejs_version: "16"
 
 platform:
   - x86

--- a/test/struct.js
+++ b/test/struct.js
@@ -1,7 +1,7 @@
 'use strict';
 var assert = require('assert')
-  , ref = require('ref-napi')
-  , ArrayType = require('ref-array-di')(ref)
+  , ref = require('@rclnodejs/ref-napi')
+  , ArrayType = require('@rclnodejs/ref-array-di')(ref)
   , Struct = require('..')(ref)
   , bindings = require('node-gyp-build')(__dirname);
 


### PR DESCRIPTION

node-gyp on node16 requires python 3.6+. The default travisci environment includes python 3.5. Thus upgraded travis.yml to use linux bionic (ubuntu 16) for a compliant version of python3. 